### PR TITLE
Create UCSBDiningCommonsMenuItemController, add GET (index) and POST (create)

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -1,0 +1,54 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@Tag(name = "UCSBDiningCommonsMenuItem")
+@RequestMapping("/api/ucsbdiningcommonsmenuitem")
+@RestController
+@Slf4j
+public class UCSBDiningCommonsMenuItemController extends ApiController {
+
+    @Autowired
+    UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+    @Operation(summary= "List all ucsb dining commons menu items")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBDiningCommonsMenuItem> allUCSBDiningCommonsMenuItems() {
+        return ucsbDiningCommonsMenuItemRepository.findAll();
+    }
+
+    @Operation(summary= "Create a new UCSB dining commons menu item")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBDiningCommonsMenuItem postUCSBDiningCommonsMenuItem(
+            @Parameter(name="diningCommonsCode") @RequestParam String diningCommonsCode,
+            @Parameter(name="name") @RequestParam String name,
+            @Parameter(name="station") @RequestParam String station) {
+        return ucsbDiningCommonsMenuItemRepository.save(UCSBDiningCommonsMenuItem.builder()
+                .diningCommonsCode(diningCommonsCode)
+                .name(name)
+                .station(station)
+                .build());
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -50,7 +50,7 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
                 .andExpect(status().is(403)); // logged out users can't get all
     }
 
-    @WithMockUser(roles = { "USER" })
+    @WithMockUser()
     @Test
     public void logged_in_users_can_get_all() throws Exception {
         mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
@@ -76,43 +76,43 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
     @Test
     @Disabled
     public void logged_out_users_cannot_put() throws Exception {
-        mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem"))
+        mockMvc.perform(put("/api/ucsbdiningcommonsmenuitem"))
                 .andExpect(status().is(403));
     }
 
     @Test
     @Disabled
     public void logged_out_users_cannot_delete() throws Exception {
-        mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem"))
+        mockMvc.perform(delete("/api/ucsbdiningcommonsmenuitem"))
                 .andExpect(status().is(403));
     }
 
-    @WithMockUser(roles = { "USER" })
+    @WithMockUser()
     @Test
     public void logged_in_regular_users_cannot_post() throws Exception {
         mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem/post"))
                 .andExpect(status().is(403)); // only admins can post
     }
 
-    @WithMockUser(roles = { "USER" })
+    @WithMockUser()
     @Test
     @Disabled
     public void logged_in_regular_users_cannot_put() throws Exception {
-        mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem"))
+        mockMvc.perform(put("/api/ucsbdiningcommonsmenuitem"))
                 .andExpect(status().is(403)); // only admins can post
     }
 
-    @WithMockUser(roles = { "USER" })
+    @WithMockUser()
     @Test
     @Disabled
     public void logged_in_regular_users_cannot_delete() throws Exception {
-        mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem"))
+        mockMvc.perform(delete("/api/ucsbdiningcommonsmenuitem"))
                 .andExpect(status().is(403)); // only admins can post
     }
 
     // Tests with mocks for database actions
 
-    @WithMockUser(roles = { "USER" })
+    @WithMockUser()
     @Test
     @Disabled
     public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
@@ -139,7 +139,7 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
         assertEquals(expectedJson, responseString);
     }
 
-    @WithMockUser(roles = { "USER" })
+    @WithMockUser()
     @Test
     @Disabled
     public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
@@ -160,7 +160,7 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
         assertEquals("UCSBDiningCommonsMenuItem with id 1 not found", json.get("message"));
     }
 
-    @WithMockUser(roles = { "USER" })
+    @WithMockUser()
     @Test
     public void logged_in_user_can_get_all_ucsbdiningcommonsmenuitems() throws Exception {
 
@@ -178,8 +178,7 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
                 .station("Entree Specials")
                 .build();
 
-        ArrayList<UCSBDiningCommonsMenuItem> expectedCommonsMenuItems = new ArrayList<>();
-        expectedCommonsMenuItems.addAll(Arrays.asList(commonsMenuItem1, commonsMenuItem2));
+        ArrayList<UCSBDiningCommonsMenuItem> expectedCommonsMenuItems = new ArrayList<>(Arrays.asList(commonsMenuItem1, commonsMenuItem2));
 
         when(ucsbDiningCommonsMenuItemRepository.findAll()).thenReturn(expectedCommonsMenuItems);
 

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -1,0 +1,342 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBDiningCommonsMenuItemController.class)
+@Import(TestConfig.class)
+public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase {
+
+    @MockBean
+    UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    // Authorization tests for /api/ucsbdiningcommons/admin/all
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+        mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+                .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+        mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+                .andExpect(status().is(200)); // logged
+    }
+
+    @Test
+    @Disabled
+    public void logged_out_users_cannot_get_by_id() throws Exception {
+        mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem?id=1"))
+                .andExpect(status().is(403)); // logged out users can't get by id
+    }
+
+    // Authorization tests for /api/ucsbdiningcommons/post
+    // (Perhaps should also have these for put and delete)
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem/post"))
+                .andExpect(status().is(403));
+    }
+
+    @Test
+    @Disabled
+    public void logged_out_users_cannot_put() throws Exception {
+        mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem"))
+                .andExpect(status().is(403));
+    }
+
+    @Test
+    @Disabled
+    public void logged_out_users_cannot_delete() throws Exception {
+        mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem/post"))
+                .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    @Disabled
+    public void logged_in_regular_users_cannot_put() throws Exception {
+        mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem"))
+                .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    @Disabled
+    public void logged_in_regular_users_cannot_delete() throws Exception {
+        mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem"))
+                .andExpect(status().is(403)); // only admins can post
+    }
+
+    // Tests with mocks for database actions
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    @Disabled
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+        // arrange
+
+        UCSBDiningCommonsMenuItem commonsMenuItem = UCSBDiningCommonsMenuItem.builder()
+                .diningCommonsCode("Ortega")
+                .name("Baked Pesto Pasta with Chicken")
+                .station("Entree Specials")
+                .build();
+
+        when(ucsbDiningCommonsMenuItemRepository.findById(eq(1L))).thenReturn(Optional.of(commonsMenuItem));
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem?id=1"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(1L));
+        String expectedJson = mapper.writeValueAsString(commonsMenuItem);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    @Disabled
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+        // arrange
+
+        when(ucsbDiningCommonsMenuItemRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem?id=1"))
+                .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(1L));
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("EntityNotFoundException", json.get("type"));
+        assertEquals("UCSBDiningCommonsMenuItem with id 1 not found", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_ucsbdiningcommonsmenuitems() throws Exception {
+
+        // arrange
+
+        UCSBDiningCommonsMenuItem commonsMenuItem1 = UCSBDiningCommonsMenuItem.builder()
+                .diningCommonsCode("Ortega")
+                .name("Baked Pesto Pasta with Chicken")
+                .station("Entree Specials")
+                .build();
+
+        UCSBDiningCommonsMenuItem commonsMenuItem2 = UCSBDiningCommonsMenuItem.builder()
+                .diningCommonsCode("Ortega")
+                .name("Tofu Banh Mi Sandwich (v)")
+                .station("Entree Specials")
+                .build();
+
+        ArrayList<UCSBDiningCommonsMenuItem> expectedCommonsMenuItems = new ArrayList<>();
+        expectedCommonsMenuItems.addAll(Arrays.asList(commonsMenuItem1, commonsMenuItem2));
+
+        when(ucsbDiningCommonsMenuItemRepository.findAll()).thenReturn(expectedCommonsMenuItems);
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedCommonsMenuItems);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_commonsmenuitem() throws Exception {
+        // arrange
+
+        UCSBDiningCommonsMenuItem commonsMenuItem1 = UCSBDiningCommonsMenuItem.builder()
+                .diningCommonsCode("Ortega")
+                .name("Baked Pesto Pasta with Chicken")
+                .station("Entree Specials")
+                .build();
+
+        when(ucsbDiningCommonsMenuItemRepository.save(any(UCSBDiningCommonsMenuItem.class))).thenReturn(commonsMenuItem1);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        post("/api/ucsbdiningcommonsmenuitem/post?diningCommonsCode=Ortega&name=Baked Pesto Pasta with Chicken&station=Entree Specials")
+                                .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(commonsMenuItem1);
+        String expectedJson = mapper.writeValueAsString(commonsMenuItem1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    @Disabled
+    public void admin_can_delete_a_menuitem() throws Exception {
+        // arrange
+
+        UCSBDiningCommonsMenuItem commonsMenuItem1 = UCSBDiningCommonsMenuItem.builder()
+                .diningCommonsCode("Ortega")
+                .name("Baked Pesto Pasta with Chicken")
+                .station("Entree Specials")
+                .build();
+
+        when(ucsbDiningCommonsMenuItemRepository.findById(eq(1L))).thenReturn(Optional.of(commonsMenuItem1));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        delete("/api/ucsbdiningcommonsmenuitem?id=1")
+                                .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(1L));
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).delete(any());
+
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("UCSBDiningCommonsMenuItem with id 1 deleted", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    @Disabled
+    public void admin_tries_to_delete_non_existant_commonsmenuitem_and_gets_right_error_message()
+            throws Exception {
+        // arrange
+
+        when(ucsbDiningCommonsMenuItemRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        delete("/api/ucsbdiningcommonsmenuitem?id=1")
+                                .with(csrf()))
+                .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(1L));
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("UCSBDiningCommonsMenuItem with id 1 not found", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    @Disabled
+    public void admin_can_edit_an_existing_commonsmenuitem() throws Exception {
+        // arrange
+
+        UCSBDiningCommonsMenuItem commonsMenuItem1 = UCSBDiningCommonsMenuItem.builder()
+                .diningCommonsCode("Ortega")
+                .name("Baked Pesto Pasta with Chicken")
+                .station("Entree Specials")
+                .build();
+
+        UCSBDiningCommonsMenuItem commonsMenuItem1Edited = UCSBDiningCommonsMenuItem.builder()
+                .diningCommonsCode("Carrillo")
+                .name("Tofu Banh Mi Sandwich (v)")
+                .station("Entree")
+                .build();
+
+        String requestBody = mapper.writeValueAsString(commonsMenuItem1Edited);
+
+        when(ucsbDiningCommonsMenuItemRepository.findById(eq(1L))).thenReturn(Optional.of(commonsMenuItem1));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        put("/api/ucsbdiningcommonsmenuitem?id=1")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .characterEncoding("utf-8")
+                                .content(requestBody)
+                                .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(1L));
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(commonsMenuItem1Edited); // should be saved with updated info
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(requestBody, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    @Disabled
+    public void admin_cannot_edit_commonsmenuitem_that_does_not_exist() throws Exception {
+        // arrange
+
+        UCSBDiningCommonsMenuItem editedCommonsMenuItem = UCSBDiningCommonsMenuItem.builder()
+                .diningCommonsCode("Ortega")
+                .name("Baked Pesto Pasta with Chicken")
+                .station("Entree Specials")
+                .build();
+
+        String requestBody = mapper.writeValueAsString(editedCommonsMenuItem);
+
+        when(ucsbDiningCommonsMenuItemRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        put("/api/ucsbdiningcommonsmenuitem?id=1")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .characterEncoding("utf-8")
+                                .content(requestBody)
+                                .with(csrf()))
+                .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(1L));
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("UCSBDiningCommonsMenuItem with id 1 not found", json.get("message"));
+
+    }
+}


### PR DESCRIPTION
In this PR, we created UCSBDiningCommonsMenuItemController, implemented the `GET /api/ucsbdiningcommonsmenuitem/all` and `POST /api/ucsbdiningcommonsmenuitem/post`  endpoints, and their respective tests.

Closes #9