### PR TITLE
Add PUT (edit) endpoint for a single record in UCSBDiningCommonsMenuItem table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -51,4 +51,19 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
                 .station(station)
                 .build());
     }
+
+    @Operation(summary= "Update a single commons menu item")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBDiningCommonsMenuItem updateCommonsMenuItem(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid UCSBDiningCommonsMenuItem incoming) {
+        UCSBDiningCommonsMenuItem commonsMenuItem = ucsbDiningCommonsMenuItemRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+        commonsMenuItem.setDiningCommonsCode(incoming.getDiningCommonsCode());
+        commonsMenuItem.setName(incoming.getName());
+        commonsMenuItem.setStation(incoming.getStation());
+        ucsbDiningCommonsMenuItemRepository.save(commonsMenuItem);
+        return commonsMenuItem;
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -74,7 +74,6 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
     }
 
     @Test
-    @Disabled
     public void logged_out_users_cannot_put() throws Exception {
         mockMvc.perform(put("/api/ucsbdiningcommonsmenuitem"))
                 .andExpect(status().is(403));
@@ -96,7 +95,6 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
     @WithMockUser()
     @Test
-    @Disabled
     public void logged_in_regular_users_cannot_put() throws Exception {
         mockMvc.perform(put("/api/ucsbdiningcommonsmenuitem"))
                 .andExpect(status().is(403)); // only admins can post
@@ -271,7 +269,6 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
     @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
-    @Disabled
     public void admin_can_edit_an_existing_commonsmenuitem() throws Exception {
         // arrange
 
@@ -309,7 +306,6 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
 
     @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
-    @Disabled
     public void admin_cannot_edit_commonsmenuitem_that_does_not_exist() throws Exception {
         // arrange
 


### PR DESCRIPTION
In this PR, we add PUT (edit) endpoint for a single record in UCSBDiningCommonsMenuItem table.

Closes #11